### PR TITLE
feat: add renovatebot config

### DIFF
--- a/REUSE.toml
+++ b/REUSE.toml
@@ -38,6 +38,12 @@ path = ".github/ISSUE_TEMPLATE/*"
 SPDX-FileCopyrightText = "2025 Sebastian Küthe and (other) contributors to project grafana-oss-team-sync <https://github.com/skuethe/grafana-oss-team-sync>"
 SPDX-License-Identifier = "GPL-3.0-or-later"
 
+# renovate.json
+[[annotations]]
+path = "renovate.json"
+SPDX-FileCopyrightText = "2025 Sebastian Küthe and (other) contributors to project grafana-oss-team-sync <https://github.com/skuethe/grafana-oss-team-sync>"
+SPDX-License-Identifier = "GPL-3.0-or-later"
+
 
 # Computer-generated files.
 [[annotations]]

--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,28 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": [
+    "config:recommended",
+    "docker:pinDigests",
+    "helpers:pinGitHubActionDigestsToSemver",
+    ":configMigration"
+  ],
+  "labels": [
+    "dependencies"
+  ],
+  "postUpdateOptions": [
+    "gomodTidy"
+  ],
+  "packageRules": [
+    {
+      "matchManagers": ["gomod"],
+      "matchDepNames": ["go"],
+      "matchDepTypes": ["golang"],
+      "rangeStrategy": "bump"
+    },
+    {
+      "matchManagers": ["gomod"],
+      "matchDepTypes": ["indirect"],
+      "enabled": true
+    }
+  ]
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
adds a `renovate.json` to enable to renovatebot app

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

- closes #9 


## How Has This Been Tested?

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
<!--- Use '[x]' (no spaces) -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- Use '[x]' (no spaces) -->

Complete these before marking the PR as `ready to review`:

- [x] I have read the [`CONTRIBUTING`](https://github.com/skuethe/grafana-oss-team-sync/blob/main/CONTRIBUTING.md) guidelines.
- [x] I signed the [DCO](https://github.com/skuethe/grafana-oss-team-sync/blob/main/CONTRIBUTING.md#sign-your-commits)
- [ ] All new and existing tests passed.
- [x] I have filled out the title and body of this PR to the best of my knowledge, to give as much insights into my changes as possible
