### PR TITLE
chore(ci): even more renovate improvements

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -34,7 +34,7 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@4afd733a84b1f43292c63897423277bb7f4313a9 # v8
         with:
-          # renovate: github=golangci/golangci-lint
+          # renovate: github-releases=golangci/golangci-lint
           version: v2.1.6
 
   build:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -39,8 +39,8 @@ jobs:
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@9c156ee8a17a598857849441385a2041ef570552 # v6.3.0
         with:
-          # renovate: github=goreleaser/goreleaser
-          version: "~> v2"
+          # renovate: github-releases=goreleaser/goreleaser
+          version: v2.10.2
           args: release --clean --config ./build/ci/.goreleaser.yaml
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/renovate.json
+++ b/renovate.json
@@ -14,6 +14,9 @@
   "postUpdateOptions": [
     "gomodTidy"
   ],
+  "docker-compose": {
+    "managerFilePatterns": ["/[^_]*_docker-compose[^/]*\\.ya?ml$/"]
+  },
   "packageRules": [
     {
       "matchManagers": ["gomod"],
@@ -42,10 +45,41 @@
       "matchPackageNames": ["github.com/knadh/koanf/**"]
     },
     {
+      "groupName": "github.com/dotnet/dev-proxy",
+      "matchPackageNames": [
+        "ghcr.io/dotnet/dev-proxy/*",
+        "github.com/dotnet/dev-proxy"
+      ]
+    },
+    {
       "groupName": "Non-breaking updates",
       "matchManagers": ["gomod"],
       "matchUpdateTypes": ["minor", "patch", "digest"],
       "matchJsonata": ["isBreaking != true"]
+    }
+  ],
+
+  "customManagers": [
+    {
+      "customType": "regex",
+      "managerFilePatterns": [
+        "/(^|/).+\\.json$/"
+      ],
+      "matchStrings": [
+        "[\\t ]*\"\\$schema\": +\"https:\\/\\/raw\\.githubusercontent\\.com\\/dotnet\\/dev-proxy\\/main\\/schemas\\/(?<currentValue>[\\w\\.-]+)\\/[\\w\\.-]+\",?"
+      ],
+      "packageNameTemplate": "github.com/dotnet/dev-proxy",
+      "datasourceTemplate": "github-releases"
+    },
+    {
+      "customType": "regex",
+      "managerFilePatterns": [
+        "/./"
+      ],
+      "matchStrings": [
+        "[\\t ]*(?:#|\\/\\/) ?renovate: (?<datasource>[^=]+)=(?<depName>\\S+)(?: registry=(?<registryUrl>\\S+))?(?: versioning=(?<versioning>\\S+))?[\\t ]*\\r?\\n.+?[:=][\\t ]*[\"']?(?<currentValue>[^@\\s\"'=]+)(?:@(?<currentDigest>sha256:[a-f0-9]+))?[\"']?"
+      ],
+      "versioningTemplate": "{{#if versioning}}{{{versioning}}}{{else if (equals datasource 'docker')}}docker{{else}}semver{{/if}}"
     }
   ]
 }

--- a/scripts/container.sh
+++ b/scripts/container.sh
@@ -11,9 +11,9 @@ SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd)
 ROOT_DIR="${SCRIPT_DIR}/../"
 DEPLOY_DIR="${ROOT_DIR}/deploy/"
 
-# renovate: github=golangci/golangci-lint
-GOLANGCI_LINT_VERSION="v2.1.6"
-# renovate: github=fsfe/reuse-tool
+# renovate: github-releases=golangci/golangci-lint
+GOLANGCI_LINT_VERSION="2.1.6"
+# renovate: github-releases=fsfe/reuse-tool
 REUSE_VERSION="5.0.2"
 
 # HELPERS
@@ -67,7 +67,7 @@ requireCommand "podman-compose"
 
 case "${1}" in
   "go-lint")
-    cd ${ROOT_DIR} && podman run --rm -v $(pwd):/app:ro -w /app docker.io/golangci/golangci-lint:${GOLANGCI_LINT_VERSION} golangci-lint run
+    cd ${ROOT_DIR} && podman run --rm -v $(pwd):/app:ro -w /app docker.io/golangci/golangci-lint:v${GOLANGCI_LINT_VERSION} golangci-lint run
     ;;
   "licenses")
     cd ${ROOT_DIR} && podman run --rm -v $(pwd):/data:ro docker.io/fsfe/reuse:${REUSE_VERSION} lint


### PR DESCRIPTION
even more renovate improvements:
- add custom `docker-compose` file names
- respect dev-proxy version within schema link inside config files
- group `dev-proxy` updates
- activate `renovate:` comment in files

closes #26 