### PR TITLE
fix(renovate): final fix respecting dev-proxy inside test folder

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -8,6 +8,9 @@
     "monorepo:azure-sdk-for-go",
     "monorepo:kiota"
   ],
+  "ignorePresets": [
+    ":ignoreModulesAndTests"
+  ],
   "labels": [
     "dependencies"
   ],
@@ -45,7 +48,7 @@
       "matchPackageNames": ["github.com/knadh/koanf/**"]
     },
     {
-      "groupName": "github.com/dotnet/dev-proxy",
+      "groupName": "dotnet/dev-proxy",
       "matchPackageNames": [
         "ghcr.io/dotnet/dev-proxy",
         "dotnet/dev-proxy"


### PR DESCRIPTION
This should now be the final (tm) fix for respecting the dev-proxy version inside the test folder.
As it turns out, the `config:recommended` has a default setup which ignores files inside `test` folders :)