### PR TITLE
chore(ci): migrate goreleaser to docker-v2

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -29,6 +29,19 @@ jobs:
         with:
           go-version-file: 'go.mod'
 
+      - name: Setup QEMU
+        uses: docker/setup-qemu-action@ce360397dd3f832beb865e1373c09c0e9f86d70a # v4.0.0
+        with:
+          platforms: linux/amd64,linux/arm64
+
+      - name: Setup BuildX
+        uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
+        with:
+          platforms: linux/amd64,linux/arm64
+
+      - name: Setup Syft
+        uses: anchore/sbom-action/download-syft@e22c389904149dbc22b58101806040fa8d37a610 # v0.24.0
+
       - name: Login to GitHub Container Registry
         uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
         with:

--- a/build/ci/.goreleaser.yaml
+++ b/build/ci/.goreleaser.yaml
@@ -32,65 +32,28 @@ archives:
       {{- else }}{{ .Arch }}{{ end }}
       {{- if .Arm }}v{{ .Arm }}{{ end }}
 
-
-dockers:
-- image_templates:
-    - "ghcr.io/skuethe/grafana-oss-team-sync:{{ .Version }}-amd64"
-    - "ghcr.io/skuethe/grafana-oss-team-sync:v{{ .Major }}-amd64"
-    - "ghcr.io/skuethe/grafana-oss-team-sync:v{{ .Major }}.{{ .Minor }}-amd64"
-    - "ghcr.io/skuethe/grafana-oss-team-sync:latest-amd64"
-  use: buildx
-  dockerfile: build/package/Dockerfile
-  build_flag_templates:
-  - "--platform=linux/amd64"
-  - --label=org.opencontainers.image.title={{ .ProjectName }}
-  - --label=org.opencontainers.image.description={{ .ProjectName }}
-  - --label=org.opencontainers.image.url=https://github.com/skuethe/grafana-oss-team-sync
-  - --label=org.opencontainers.image.source=https://github.com/skuethe/grafana-oss-team-sync
-  - --label=org.opencontainers.image.version={{ .Version }}
-  - --label=org.opencontainers.image.created={{ time "2006-01-02T15:04:05Z07:00" }}
-  - --label=org.opencontainers.image.revision={{ .FullCommit }}
-  - --label=org.opencontainers.image.licenses=GPL-3.0-or-later
-- image_templates:
-    - "ghcr.io/skuethe/grafana-oss-team-sync:{{ .Version }}-arm64v8"
-    - "ghcr.io/skuethe/grafana-oss-team-sync:v{{ .Major }}-arm64v8"
-    - "ghcr.io/skuethe/grafana-oss-team-sync:v{{ .Major }}.{{ .Minor }}-arm64v8"
-    - "ghcr.io/skuethe/grafana-oss-team-sync:latest-arm64v8"
-  use: buildx
-  goarch: arm64
-  dockerfile: build/package/Dockerfile
-  build_flag_templates:
-  - "--platform=linux/arm64/v8"
-  - --label=org.opencontainers.image.title={{ .ProjectName }}
-  - --label=org.opencontainers.image.description={{ .ProjectName }}
-  - --label=org.opencontainers.image.url=https://github.com/skuethe/grafana-oss-team-sync
-  - --label=org.opencontainers.image.source=https://github.com/skuethe/grafana-oss-team-sync
-  - --label=org.opencontainers.image.version={{ .Version }}
-  - --label=org.opencontainers.image.created={{ time "2006-01-02T15:04:05Z07:00" }}
-  - --label=org.opencontainers.image.revision={{ .FullCommit }}
-  - --label=org.opencontainers.image.licenses=GPL-3.0-or-later
-
-
-docker_manifests:
-- name_template: "ghcr.io/skuethe/grafana-oss-team-sync:{{ .Version }}"
-  image_templates:
-    - "ghcr.io/skuethe/grafana-oss-team-sync:{{ .Version }}-amd64"
-    - "ghcr.io/skuethe/grafana-oss-team-sync:{{ .Version }}-arm64v8"
-
-- name_template: "ghcr.io/skuethe/grafana-oss-team-sync:v{{ .Major }}"
-  image_templates:
-    - "ghcr.io/skuethe/grafana-oss-team-sync:v{{ .Major }}-amd64"
-    - "ghcr.io/skuethe/grafana-oss-team-sync:v{{ .Major }}-arm64v8"
-
-- name_template: "ghcr.io/skuethe/grafana-oss-team-sync:v{{ .Major }}.{{ .Minor }}"
-  image_templates:
-    - "ghcr.io/skuethe/grafana-oss-team-sync:v{{ .Major }}.{{ .Minor }}-amd64"
-    - "ghcr.io/skuethe/grafana-oss-team-sync:v{{ .Major }}.{{ .Minor }}-arm64v8"
-
-- name_template: "ghcr.io/skuethe/grafana-oss-team-sync:latest"
-  image_templates:
-    - "ghcr.io/skuethe/grafana-oss-team-sync:latest-amd64"
-    - "ghcr.io/skuethe/grafana-oss-team-sync:latest-arm64v8"
+dockers_v2:
+  - images:
+      - "ghcr.io/skuethe/grafana-oss-team-sync"
+    tags:
+      - "{{ .Version }}"
+      - "v{{ .Major }}"
+      - "v{{ .Major }}.{{ .Minor }}"
+      - "latest"
+    labels:
+      "org.opencontainers.image.created": "{{ .Date }}"
+      "org.opencontainers.image.description": "{{ .ProjectName }}"
+      "org.opencontainers.image.licenses": "GPL-3.0-or-later"
+      "org.opencontainers.image.revision": "{{ .FullCommit }}"
+      "org.opencontainers.image.source": "https://github.com/skuethe/grafana-oss-team-sync"
+      "org.opencontainers.image.title": "{{ .ProjectName }}"
+      "org.opencontainers.image.url": "https://github.com/skuethe/grafana-oss-team-sync"
+      "org.opencontainers.image.version": "{{ .Version }}"
+    dockerfile: build/package/Dockerfile
+    platforms:
+      - linux/amd64
+      - linux/arm64
+    sbom: true
 
 
 nfpms:

--- a/build/package/Dockerfile
+++ b/build/package/Dockerfile
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 FROM scratch
-COPY --from=docker.io/golang:alpine@sha256:f85330846cde1e57ca9ec309382da3b8e6ae3ab943d2739500e08c86393a21b1 /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
-COPY grafana-oss-team-sync /usr/bin/grafana-oss-team-sync
+ARG TARGETPLATFORM
 ENTRYPOINT ["/usr/bin/grafana-oss-team-sync"]
+COPY --from=docker.io/golang:alpine@sha256:f85330846cde1e57ca9ec309382da3b8e6ae3ab943d2739500e08c86393a21b1 /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
+COPY $TARGETPLATFORM/grafana-oss-team-sync /usr/bin/grafana-oss-team-sync


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Migrate goreleaser from `dockers` and `docker_manifests` to `dockers_v2`, simplifying the goreleaser configuration for multi arch docker builds.  

See:  
https://goreleaser.com/resources/deprecations/#dockers

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
<!--- Use '[x]' (no spaces) -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

Complete these before marking the PR as `ready to review`:

- [x] I have read the [`CONTRIBUTING`](https://github.com/skuethe/grafana-oss-team-sync/blob/main/CONTRIBUTING.md) guidelines.
- [x] I signed the [DCO](https://github.com/skuethe/grafana-oss-team-sync/blob/main/CONTRIBUTING.md#sign-your-commits)
- [ ] All new and existing tests passed.
- [x] I have filled out the title and body of this PR to the best of my knowledge, to give as much insights into my changes as possible
