### PR TITLE
fix(ci): switch to grafana/grafana container image

### DIFF
--- a/.github/workflows/extended-tests.yaml
+++ b/.github/workflows/extended-tests.yaml
@@ -30,7 +30,7 @@ jobs:
     # Define service containers for integration tests
     services:
       grafana:
-        image: docker.io/grafana/grafana-oss:${{ matrix.version }}
+        image: docker.io/grafana/grafana:${{ matrix.version }}
         ports:
           - 3000:3000
         options: >-
@@ -93,7 +93,7 @@ jobs:
 
       # Start latest Grafana stable, to run e2e tests against
       grafana:
-        image: docker.io/grafana/grafana-oss:latest@sha256:5dad0df181cb644a14e13617b913b261a54f7d4fd4510721dba420929f35bea2
+        image: docker.io/grafana/grafana:latest@sha256:5dad0df181cb644a14e13617b913b261a54f7d4fd4510721dba420929f35bea2
         ports:
           - 3000:3000
         options: >-

--- a/deploy/e2e-tests_docker-compose.yaml
+++ b/deploy/e2e-tests_docker-compose.yaml
@@ -3,7 +3,7 @@
 
 services:
   grafana:
-    image: docker.io/grafana/grafana-oss:latest@sha256:5dad0df181cb644a14e13617b913b261a54f7d4fd4510721dba420929f35bea2
+    image: docker.io/grafana/grafana:latest@sha256:5dad0df181cb644a14e13617b913b261a54f7d4fd4510721dba420929f35bea2
     container_name: grafana
     restart: unless-stopped
     ports:

--- a/deploy/e2e-tests_docker-compose_devproxy-record.yaml
+++ b/deploy/e2e-tests_docker-compose_devproxy-record.yaml
@@ -3,7 +3,7 @@
 
 services:
   grafana:
-    image: docker.io/grafana/grafana-oss:latest@sha256:5dad0df181cb644a14e13617b913b261a54f7d4fd4510721dba420929f35bea2
+    image: docker.io/grafana/grafana:latest@sha256:5dad0df181cb644a14e13617b913b261a54f7d4fd4510721dba420929f35bea2
     container_name: grafana
     restart: unless-stopped
     ports:

--- a/deploy/integration-tests_docker-compose.yaml
+++ b/deploy/integration-tests_docker-compose.yaml
@@ -4,7 +4,7 @@
 services:
 
   grafana:
-    image: docker.io/grafana/grafana-oss:latest@sha256:5dad0df181cb644a14e13617b913b261a54f7d4fd4510721dba420929f35bea2
+    image: docker.io/grafana/grafana:latest@sha256:5dad0df181cb644a14e13617b913b261a54f7d4fd4510721dba420929f35bea2
     container_name: grafana
     restart: unless-stopped
     ports:

--- a/deploy/integration-tests_override_grafana-11.1.0.yaml
+++ b/deploy/integration-tests_override_grafana-11.1.0.yaml
@@ -4,4 +4,4 @@
 services:
 
   grafana:
-    image: docker.io/grafana/grafana-oss:11.1.0@sha256:079600c9517b678c10cda6006b4487d3174512fd4c6cface37df7822756ed7a5
+    image: docker.io/grafana/grafana:11.1.0@sha256:079600c9517b678c10cda6006b4487d3174512fd4c6cface37df7822756ed7a5

--- a/deploy/integration-tests_override_grafana-12.0.0.yaml
+++ b/deploy/integration-tests_override_grafana-12.0.0.yaml
@@ -4,4 +4,4 @@
 services:
 
   grafana:
-    image: docker.io/grafana/grafana-oss:12.0.0@sha256:263cbefd5d9b179893c47c415daab4da5c1f3d6770154741eca4f45c81119884
+    image: docker.io/grafana/grafana:12.0.0@sha256:263cbefd5d9b179893c47c415daab4da5c1f3d6770154741eca4f45c81119884

--- a/deploy/local-tests_docker-compose.yaml
+++ b/deploy/local-tests_docker-compose.yaml
@@ -3,7 +3,7 @@
 
 services:
   grafana:
-    image: docker.io/grafana/grafana-oss:latest@sha256:5dad0df181cb644a14e13617b913b261a54f7d4fd4510721dba420929f35bea2
+    image: docker.io/grafana/grafana:latest@sha256:5dad0df181cb644a14e13617b913b261a54f7d4fd4510721dba420929f35bea2
     container_name: grafana
     restart: unless-stopped
     ports:


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Grafana stopped publishing the `grafana/grafana-oss` container image. Since then we stopped receiving renovate updates to the extended tests and docker compose files.
Grafana has documented to switch to the `grafana/grafana` container image instead, as it contains the same OSS release.
See [these notes](https://github.com/grafana/grafana/blob/bd90250268a0255f95840ef082857e96747cfa86/docs/sources/setup-grafana/configure-docker.md?plain=1#L21-L24)

## How Has This Been Tested?
I validated that the currently used container tags + digests work on the `grafana/grafana` images as well, so we can just change the base image.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
<!--- Use '[x]' (no spaces) -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- Use '[x]' (no spaces) -->

Complete these before marking the PR as `ready to review`:

- [x] I have read the [`CONTRIBUTING`](https://github.com/skuethe/grafana-oss-team-sync/blob/main/CONTRIBUTING.md) guidelines.
- [x] I signed the [DCO](https://github.com/skuethe/grafana-oss-team-sync/blob/main/CONTRIBUTING.md#sign-your-commits)
- [x] All new and existing tests passed.
- [x] I have filled out the title and body of this PR to the best of my knowledge, to give as much insights into my changes as possible
